### PR TITLE
Feature/triangle primitives

### DIFF
--- a/bacon/commands.py
+++ b/bacon/commands.py
@@ -58,6 +58,14 @@ def DrawLine(x1, y1, x2, y2):
     _commands.append(native.Commands.draw_line)
     _data.extend((x1, y1, x2, y2))
 
+def DrawTriangle(x1, y1, x2, y2, x3, y3):
+    _commands.append(native.Commands.draw_triangle)
+    _data.extend((x1, y1, x2, y2, x3, y3))
+
+def FillTriangle(x1, y1, x2, y2, x3, y3):
+    _commands.append(native.Commands.fill_triangle)
+    _data.extend((x1, y1, x2, y2, x3, y3))
+
 def DrawRect(x1, y1, x2, y2):
     _commands.append(native.Commands.draw_rect)
     _data.extend((x1, y1, x2, y2))
@@ -123,6 +131,8 @@ def init():
     lib.DrawImage = DrawImage
     lib.DrawImageRegion = DrawImageRegion
     lib.DrawLine = DrawLine
+    lib.DrawTriangle = DrawTriangle
+    lib.FillTriangle = FillTriangle
     lib.DrawRect = DrawRect
     lib.FillRect = FillRect
     lib.SetShaderUniformFloats = SetShaderUniformFloats

--- a/bacon/graphics.py
+++ b/bacon/graphics.py
@@ -239,3 +239,23 @@ fill_rect.__doc__ = '''Fill a rectangle bounding coordinates ``(x1, y1)`` to ``(
 
 No texture is applied.
 '''
+
+if native._mock_native:
+    def draw_triangle(x1, y1, x2, y2, x3, y3):
+        pass
+else:
+    draw_triangle = lib.DrawTriangle
+draw_triangle.__doc__ = '''Draw a triangle with coordinates ``(x1, y1)``, ``(x2, y2)``, ``(x3, y3)``.
+
+No texture is applied.
+'''
+
+if native._mock_native:
+    def fill_triangle(x1, y1, x2, y2, x3, y3):
+        pass
+else:
+    fill_triangle = lib.FillTriangle
+fill_triangle.__doc__ = '''Fill a triangle with coordinates ``(x1, y1)``, ``(x2, y2)``, ``(x3, y3)``.
+
+No texture is applied.
+'''

--- a/bacon/native.py
+++ b/bacon/native.py
@@ -115,16 +115,18 @@ class Commands(object):
     draw_image_region = 12
     draw_image_quad = 13
     draw_line = 14
-    draw_rect = 15
-    fill_rect = 16
-    set_shader_uniform_floats = 17
-    set_shader_uniform_ints = 18
-    set_shared_shader_uniform_floats = 19
-    set_shared_shader_uniform_ints = 20
-    set_shader = 21
-    clear = 22
-    set_frame_buffer = 23
-    set_viewport = 24
+    draw_triangle = 15
+    fill_triangle = 16
+    draw_rect = 17
+    fill_rect = 18
+    set_shader_uniform_floats = 19
+    set_shader_uniform_ints = 20
+    set_shared_shader_uniform_floats = 21
+    set_shared_shader_uniform_ints = 22
+    set_shader = 23
+    clear = 24
+    set_frame_buffer = 25
+    set_viewport = 26
 
 '''Blend values that can be passed to set_blending'''
 @enum
@@ -559,6 +561,8 @@ def load(function_wrapper = None):
     DrawImage = fn(_lib.Bacon_DrawImage, c_int, c_float, c_float, c_float, c_float)
     DrawImageRegion = fn(_lib.Bacon_DrawImageRegion, c_int, c_float, c_float, c_float, c_float, c_float, c_float, c_float, c_float)
     DrawLine = fn(_lib.Bacon_DrawLine, c_float, c_float, c_float, c_float)
+    FillTriangle = fn(_lib.Bacon_FillTriangle, c_float, c_float, c_float, c_float, c_float, c_float)
+    DrawTriangle = fn(_lib.Bacon_FillTriangle, c_float, c_float, c_float, c_float, c_float, c_float)
     DrawRect = fn(_lib.Bacon_DrawRect, c_float, c_float, c_float, c_float)
     FillRect = fn(_lib.Bacon_FillRect, c_float, c_float, c_float, c_float)
 

--- a/doc/graphics.rst
+++ b/doc/graphics.rst
@@ -21,6 +21,11 @@ Rectangles can drawn or filled in the current color with :func:`draw_rect` and :
 .. literalinclude:: ../examples/rect.py
     :emphasize-lines: 7,9
 
+Triangles can be drawn or filled in the current color with :func:`draw_triangle` and :func:`fill_triangle`:
+
+.. literalinclude:: ../examples/triangles.py
+    :emphasize-lines: 8,10
+
 Lines can similarly be drawn with :func:`draw_line`.
 
 Images

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -79,6 +79,8 @@ Drawing
 .. autofunction:: clear
 
 .. autofunction:: draw_line
+.. autofunction:: draw_triangle
+.. autofunction:: fill_triangle
 .. autofunction:: draw_rect
 .. autofunction:: fill_rect
 

--- a/examples/triangles.py
+++ b/examples/triangles.py
@@ -3,9 +3,16 @@ import bacon
 class Game(bacon.Game):
     def on_tick(self):
         bacon.clear(0, 0, 0, 1)
-        bacon.set_color(1, 0, 0, 1)
+
+        bacon.set_color(0, 1, 0, 1)
         bacon.fill_triangle(0, 0, 0, 100, 100, 0)
+        bacon.set_color(1, 0, 0, 1)
+        bacon.draw_triangle(0, 0, 0, 100, 100, 0)
+
         bacon.set_color(0, 1, 0, 1)
         bacon.fill_triangle(100, 100, 150, 100, 200, 300)
-        bacon.draw_rect(400, 400, 500, 500)
+        bacon.set_color(1, 0, 0, 1)
+        bacon.draw_triangle(100, 100, 150, 100, 200, 300)
+
+
 bacon.run(Game())

--- a/examples/triangles.py
+++ b/examples/triangles.py
@@ -1,0 +1,11 @@
+import bacon
+
+class Game(bacon.Game):
+    def on_tick(self):
+        bacon.clear(0, 0, 0, 1)
+        bacon.set_color(1, 0, 0, 1)
+        bacon.fill_triangle(0, 0, 0, 100, 100, 0)
+        bacon.set_color(0, 1, 0, 1)
+        bacon.fill_triangle(100, 100, 150, 100, 200, 300)
+        bacon.draw_rect(400, 400, 500, 500)
+bacon.run(Game())

--- a/native/Source/Bacon/Bacon.h
+++ b/native/Source/Bacon/Bacon.h
@@ -212,6 +212,8 @@ enum Bacon_Commands
 	Bacon_Command_DrawImageRegion,
 	Bacon_Command_DrawImageQuad,
 	Bacon_Command_DrawLine,
+	Bacon_Command_DrawTriangle,
+	Bacon_Command_FillTriangle,
 	Bacon_Command_DrawRect,
 	Bacon_Command_FillRect,
 	Bacon_Command_SetShaderUniformFloats,
@@ -395,6 +397,8 @@ extern "C" {
 				            			float ix1, float iy1, float ix2, float iy2);
 	BACON_API int Bacon_DrawImageQuad(int image, float* positions, float* texCoords, float* colors);
 	BACON_API int Bacon_DrawLine(float x1, float y1, float x2, float y2);
+	BACON_API int Bacon_DrawTriangle(float x1, float y1, float x2, float y2, float x3, float y3);
+	BACON_API int Bacon_FillTriangle(float x1, float y1, float x2, float y2, float x3, float y3);
 	BACON_API int Bacon_DrawRect(float x1, float y1, float x2, float y2);
 	BACON_API int Bacon_FillRect(float x1, float y1, float x2, float y2);
 	

--- a/native/Source/Bacon/CommandList.cpp
+++ b/native/Source/Bacon/CommandList.cpp
@@ -116,6 +116,28 @@ int Bacon_ExecuteCommands(int* commands, int commandCount, float* data, int data
 				Bacon_DrawLine(x1, y1, x2, y2);
 				break;
 			}
+			case Bacon_Command_DrawTriangle:
+			{
+				float x1 = *data++;
+				float y1 = *data++;
+				float x2 = *data++;
+				float y2 = *data++;
+				float x3 = *data++;
+				float y3 = *data++;
+				Bacon_DrawTriangle(x1, y1, x2, y2, x3, y3);
+				break;
+			}
+			case Bacon_Command_FillTriangle:
+			{
+				float x1 = *data++;
+				float y1 = *data++;
+				float x2 = *data++;
+				float y2 = *data++;
+				float x3 = *data++;
+				float y3 = *data++;
+				Bacon_FillTriangle(x1, y1, x2, y2, x3, y3);
+				break;
+			}
 			case Bacon_Command_DrawRect:
 			{
 				float x1 = *data++;

--- a/native/Source/Bacon/Graphics.cpp
+++ b/native/Source/Bacon/Graphics.cpp
@@ -2021,6 +2021,53 @@ int Bacon_DrawLine(float x1, float y1, float x2, float y2)
 	return Bacon_Error_None;
 }
 
+int Graphics_DrawTriangle(float x1, float y1, float x2, float y2, float x3, float y3, bool filled)
+{
+	Image* image = GetBlankImage();
+	if (!image)
+		return Bacon_Error_InvalidHandle; // TODO
+
+	SetCurrentImage(image);
+	if (filled)
+		SetCurrentMode(GL_TRIANGLES);
+	else
+		SetCurrentMode(GL_LINE_LOOP);
+
+	RequireVertices(3);
+	RequireIndices(3);
+
+	float z = s_Impl->m_CurrentZ;
+	mat4f const& transform = s_Impl->m_TransformStack.back();
+	vec4f const& color = s_Impl->m_ColorStack.back();
+	vector<Vertex>& vertices = s_Impl->m_Vertices;
+	unsigned short index = vertices.size();
+	vertices.push_back(Vertex(transform * vec3f(x1, y1, z), image->m_UVScaleBias.Apply(vec2f(0, 1)), color));
+	vertices.push_back(Vertex(transform * vec3f(x2, y2, z), image->m_UVScaleBias.Apply(vec2f(1, 0)), color));
+	vertices.push_back(Vertex(transform * vec3f(x3, y3, z), image->m_UVScaleBias.Apply(vec2f(1, 1)), color));
+
+	vector<unsigned short>& indices = s_Impl->m_Indices;
+	indices.push_back(index + 0);
+	indices.push_back(index + 1);
+	indices.push_back(index + 2);
+
+	return Bacon_Error_None;
+}
+
+
+int Bacon_DrawTriangle(float x1, float y1, float x2, float y2, float x3, float y3)
+{
+	REQUIRE_GL();
+
+	return Graphics_DrawTriangle(x1, y1, x2, y2, x3, y3, false);
+}
+
+int Bacon_FillTriangle(float x1, float y1, float x2, float y2, float x3, float y3)
+{
+	REQUIRE_GL();
+
+	return Graphics_DrawTriangle(x1, y1, x2, y2, x3, y3, true);
+}
+
 static unsigned short DrawRectIndices[] = {
 	0, 1,
 	1, 2,


### PR DESCRIPTION
Added functions for drawing new primitives: triangles. I think it will be nice to have such simple primitive in bacon api. I needed it to draw some shadow maps.

C++ code changes need your carefull review because I'm not familiar with whole codebase yet and there are no guidelines for contributors. I left a notes in diff parts where I'm not sure if my changes are correct.

Code was builded/tested only on Mac OS X because my windows environment is FUBAR.

BTW: it was quite hard to figure out how to get this lib working for development. If you have an easy workflow for fast development that doesn't require building for both environments or overriding `build.py` script behaviour it would be nice if you share it somewhere in docs.
